### PR TITLE
Reload the engine asynchronously

### DIFF
--- a/src/main/java/team/creative/ambientsounds/AmbientSounds.java
+++ b/src/main/java/team/creative/ambientsounds/AmbientSounds.java
@@ -10,7 +10,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.server.packs.resources.ReloadableResourceManager;
 import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.neoforged.fml.common.Mod;
 import team.creative.ambientsounds.engine.AmbientEngine;
@@ -20,23 +20,26 @@ import team.creative.creativecore.ICreativeLoader;
 import team.creative.creativecore.client.ClientLoader;
 import team.creative.creativecore.client.CreativeCoreClient;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 @Mod(value = AmbientSounds.MODID)
 public class AmbientSounds implements ClientLoader {
-    
+
     public static final Logger LOGGER = LogManager.getLogger(AmbientSounds.MODID);
     public static final String MODID = "ambientsounds";
     public static final AmbientSoundsConfig CONFIG = new AmbientSoundsConfig();
     public static AmbientTickHandler TICK_HANDLER;
-    
+
     public AmbientSounds() {
         ICreativeLoader loader = CreativeCore.loader();
         loader.registerClient(this);
     }
-    
+
     public static void scheduleReload() {
         TICK_HANDLER.scheduleReload();
     }
-    
+
     public static void reload() {
         if (TICK_HANDLER.engine != null)
             TICK_HANDLER.engine.stopEngine();
@@ -44,37 +47,37 @@ public class AmbientSounds implements ClientLoader {
             TICK_HANDLER.environment.reload();
         TICK_HANDLER.setEngine(AmbientEngine.loadAmbientEngine(TICK_HANDLER.soundEngine));
     }
-    
+
     @Override
     public void onInitializeClient() {
         ICreativeLoader loader = CreativeCore.loader();
-        
+
         TICK_HANDLER = new AmbientTickHandler();
         loader.registerClientTick(TICK_HANDLER::onTick);
         loader.registerClientRenderGui(TICK_HANDLER::onRender);
         loader.registerLoadLevel(TICK_HANDLER::loadLevel);
-        
+
         loader.registerClientStarted(() -> {
             Minecraft minecraft = Minecraft.getInstance();
             ReloadableResourceManager reloadableResourceManager = (ReloadableResourceManager) minecraft.getResourceManager();
-            
-            reloadableResourceManager.registerReloadListener(new SimplePreparableReloadListener() {
-                
+
+            reloadableResourceManager.registerReloadListener(new PreparableReloadListener() {
+
                 @Override
-                protected void apply(Object p_10793_, ResourceManager p_10794_, ProfilerFiller p_10795_) {
-                    AmbientSounds.reload();
-                }
-                
-                @Override
-                protected Object prepare(ResourceManager p_10796_, ProfilerFiller p_10797_) {
-                    return null;
+                public CompletableFuture<Void> reload(PreparationBarrier preparationBarrier, ResourceManager resourceManager, ProfilerFiller prepareProfiler, ProfilerFiller applyProfiler, Executor prepareExecutor, Executor applyExecutor) {
+	                return CompletableFuture.supplyAsync(() -> {
+		                AmbientSounds.reload();
+
+                        preparationBarrier.wait(null);
+	                    return null;
+	                }, applyExecutor);
                 }
             });
         });
-        
+
         CreativeCoreClient.registerClientConfig(MODID);
     }
-    
+
     @Override
     public <T> void registerClientCommands(CommandDispatcher<T> dispatcher) {
         dispatcher.register(LiteralArgumentBuilder.<T>literal("ambient-debug").executes(x -> {
@@ -86,5 +89,5 @@ public class AmbientSounds implements ClientLoader {
             return Command.SINGLE_SUCCESS;
         }));
     }
-    
+
 }


### PR DESCRIPTION
Minecraft still has to wait for the engine reload to finish, but it happens on the side now without blocking the main thread.
Same patch can be applied to 1.20 without any changes needed.

## VisualVM sampler results

Before:  
![Before](https://github.com/user-attachments/assets/00b4c67d-eb6c-4673-987e-5b478cb5cdda)

After:  
![After](https://github.com/user-attachments/assets/f04fc465-a68d-44d0-803a-ebce69d4237f)
