### PR TITLE
Fix async engine reloading

### DIFF
--- a/src/main/java/team/creative/ambientsounds/AmbientSounds.java
+++ b/src/main/java/team/creative/ambientsounds/AmbientSounds.java
@@ -1,6 +1,6 @@
 package team.creative.ambientsounds;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import net.minecraft.Util;
 import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,21 +24,15 @@ import team.creative.creativecore.client.ClientLoader;
 import team.creative.creativecore.client.CreativeCoreClient;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
 @Mod(value = AmbientSounds.MODID)
 public class AmbientSounds implements ClientLoader {
 
     public static final Logger LOGGER = LogManager.getLogger(AmbientSounds.MODID);
     public static final String MODID = "ambientsounds";
-    public static final String MOD_NAME = "AmbientSounds";
     public static final AmbientSoundsConfig CONFIG = new AmbientSoundsConfig();
 
     public static AmbientTickHandler TICK_HANDLER;
-
-    private static final @NotNull Executor RELOAD_THREAD_POOL_EXECUTOR = Executors.newFixedThreadPool(
-            1, new ThreadFactoryBuilder().setNameFormat(String.format("%s Reloader", MOD_NAME)).build());
 
     public AmbientSounds() {
         ICreativeLoader loader = CreativeCore.loader();
@@ -50,10 +44,10 @@ public class AmbientSounds implements ClientLoader {
     }
 
     public static void reloadAsync() {
-        CompletableFuture.runAsync(AmbientSounds::reload, RELOAD_THREAD_POOL_EXECUTOR);
+        CompletableFuture.runAsync(AmbientSounds::reload, Util.backgroundExecutor());
     }
 
-    private static void reload() {
+    private static synchronized void reload() {
         if (TICK_HANDLER.engine != null)
             TICK_HANDLER.engine.stopEngine();
         if (TICK_HANDLER.environment != null)

--- a/src/main/java/team/creative/ambientsounds/AmbientSounds.java
+++ b/src/main/java/team/creative/ambientsounds/AmbientSounds.java
@@ -1,5 +1,7 @@
 package team.creative.ambientsounds;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -10,9 +12,10 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.server.packs.resources.ReloadableResourceManager;
 import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.neoforged.fml.common.Mod;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import team.creative.ambientsounds.engine.AmbientEngine;
 import team.creative.ambientsounds.engine.AmbientTickHandler;
 import team.creative.creativecore.CreativeCore;
@@ -22,14 +25,20 @@ import team.creative.creativecore.client.CreativeCoreClient;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 @Mod(value = AmbientSounds.MODID)
 public class AmbientSounds implements ClientLoader {
 
     public static final Logger LOGGER = LogManager.getLogger(AmbientSounds.MODID);
     public static final String MODID = "ambientsounds";
+    public static final String MOD_NAME = "AmbientSounds";
     public static final AmbientSoundsConfig CONFIG = new AmbientSoundsConfig();
+
     public static AmbientTickHandler TICK_HANDLER;
+
+    private static final @NotNull Executor RELOAD_THREAD_POOL_EXECUTOR = Executors.newFixedThreadPool(
+            1, new ThreadFactoryBuilder().setNameFormat(String.format("%s Reloader", MOD_NAME)).build());
 
     public AmbientSounds() {
         ICreativeLoader loader = CreativeCore.loader();
@@ -40,7 +49,11 @@ public class AmbientSounds implements ClientLoader {
         TICK_HANDLER.scheduleReload();
     }
 
-    public static void reload() {
+    public static void reloadAsync() {
+        CompletableFuture.runAsync(AmbientSounds::reload, RELOAD_THREAD_POOL_EXECUTOR);
+    }
+
+    private static void reload() {
         if (TICK_HANDLER.engine != null)
             TICK_HANDLER.engine.stopEngine();
         if (TICK_HANDLER.environment != null)
@@ -61,16 +74,17 @@ public class AmbientSounds implements ClientLoader {
             Minecraft minecraft = Minecraft.getInstance();
             ReloadableResourceManager reloadableResourceManager = (ReloadableResourceManager) minecraft.getResourceManager();
 
-            reloadableResourceManager.registerReloadListener(new PreparableReloadListener() {
+            reloadableResourceManager.registerReloadListener(new SimplePreparableReloadListener<Void>() {
+                @SuppressWarnings("NullableProblems")
+                @Override
+                protected @Nullable Void prepare(@NotNull ResourceManager resourceManager, @NotNull ProfilerFiller profilerFiller) {
+                    AmbientSounds.reloadAsync();
+                    return null;
+                }
 
                 @Override
-                public CompletableFuture<Void> reload(PreparationBarrier preparationBarrier, ResourceManager resourceManager, ProfilerFiller prepareProfiler, ProfilerFiller applyProfiler, Executor prepareExecutor, Executor applyExecutor) {
-	                return CompletableFuture.supplyAsync(() -> {
-		                AmbientSounds.reload();
-
-                        preparationBarrier.wait(null);
-	                    return null;
-	                }, applyExecutor);
+                protected void apply(@Nullable Void object, @NotNull ResourceManager resourceManager, @NotNull ProfilerFiller profilerFiller) {
+                    // NO-OP
                 }
             });
         });
@@ -85,7 +99,7 @@ public class AmbientSounds implements ClientLoader {
             return Command.SINGLE_SUCCESS;
         }));
         dispatcher.register(LiteralArgumentBuilder.<T>literal("ambient-reload").executes(x -> {
-            AmbientSounds.reload();
+            AmbientSounds.reloadAsync();
             return Command.SINGLE_SUCCESS;
         }));
     }

--- a/src/main/java/team/creative/ambientsounds/engine/AmbientEngine.java
+++ b/src/main/java/team/creative/ambientsounds/engine/AmbientEngine.java
@@ -191,7 +191,7 @@ public class AmbientEngine {
         return map;
     }
     
-    public static AmbientEngine loadAmbientEngine(AmbientSoundEngine soundEngine) {
+    public static synchronized AmbientEngine loadAmbientEngine(AmbientSoundEngine soundEngine) {
         try {
             ResourceManager manager = Minecraft.getInstance().getResourceManager();
             

--- a/src/main/java/team/creative/ambientsounds/engine/AmbientTickHandler.java
+++ b/src/main/java/team/creative/ambientsounds/engine/AmbientTickHandler.java
@@ -153,7 +153,7 @@ public class AmbientTickHandler {
         }
         
         if (shouldReload) {
-            AmbientSounds.reload();
+            AmbientSounds.reloadAsync();
             shouldReload = false;
         }
         


### PR DESCRIPTION
Also made the `/ambient-reload` command reload the engine asynchronously.
Follow-up PR to #246, should avoid any resource reload (compatibility) issues in the future such as https://github.com/IMB11/Fog/issues/23.

If you spam the command/resource reload fast enough it'll keep reloading the engine with this code, though I'm not sure if that's a big issue requiring a fix currently. You'd have to check if a `CompletableFuture<Void>` field is already reloading the engine.