### PR TITLE
Prevent loading mod on NeoForge servers

### DIFF
--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -12,6 +12,7 @@ license="LGPL-3.0-only"
     authors="CreativeMD"
     description='''Expands minecraft's ambient sounds.'''
     displayTest="NONE"
+    side="CLIENT"
 
 [[dependencies.ambientsounds]]
     modId="neoforge"


### PR DESCRIPTION
This PR prevents crashes that occur, when this mod is loaded on a NeoForge server, by disabling it on the server.
The fabric.mod.json already contains the equivalent option (`"environment": "client"`).