### PR TITLE
Fix Serene Seasons Compatibility

### DIFF
--- a/src/main/java/team/creative/ambientsounds/mod/SereneSeasonsCompat.java
+++ b/src/main/java/team/creative/ambientsounds/mod/SereneSeasonsCompat.java
@@ -18,7 +18,7 @@ public class SereneSeasonsCompat {
         Method temp = null;
         try {
             Class clazz = Class.forName("sereneseasons.season.SeasonHooks");
-            temp = ReflectionHelper.findMethod(clazz, "getBiomeTemperature", Level.class, Holder.class, BlockPos.class);
+            temp = ReflectionHelper.findMethod(clazz, "getBiomeTemperature", Level.class, Holder.class, BlockPos.class, int.class);
         } catch (Exception e) {}
         getBiomeTemperature = temp;
     }
@@ -28,7 +28,7 @@ public class SereneSeasonsCompat {
         Holder<Biome> biome = level.getBiome(player.blockPosition());
         if (getBiomeTemperature != null)
             try {
-                return (float) getBiomeTemperature.invoke(null, level, biome, player.blockPosition());
+                return (float) getBiomeTemperature.invoke(null, level, biome, player.blockPosition(), level.getSeaLevel());
             } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
Glitchfiend/SereneSeasons@c3c228a (first released in SereneSeasons 10.2.0) changed the signature of `getBiomeTemperature()`, and since then this compatibility layer has silently fallen back on the static `biome.value().getBaseTemperature()` to report the temperature. This PR updates two lines to match the new signature; this restores seasonal temperature changes.

Tested and working in SP and MP Minecraft 1.21.4 / fabric 0.110.5 / loom 1.8.13 / CreativeCore 2.12.22 / SereneSeasons 10.4.0