### PR TITLE
Add contact information to fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,6 +8,11 @@
         "CreativeMD",
         "AriaFreeze"
     ],
+    "contact": {
+        "sources": "https://github.com/CreativeMD/AmbientSounds",
+        "homepage": "https://modrinth.com/mod/appleskin",
+        "issues": "https://github.com/CreativeMD/AmbientSounds/issues"
+    },
     "license": "LGPL-3.0-only",
     "icon": "ambientsounds.png",
     "environment": "client",


### PR DESCRIPTION
Added contact information with sources, homepage, and issues links. Homepage is used in MultiMC to track updates.